### PR TITLE
[COMMON + TYPESCRIPT] Add Magic Numbers Rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@techmmunity/eslint-config",
-	"version": "3.3.2",
+	"version": "4.0.0",
 	"license": "Apache-2.0",
 	"author": "Techmmunity",
 	"description": "Techmmunity Style Guide",

--- a/src/common.js
+++ b/src/common.js
@@ -17,6 +17,12 @@ module.exports = {
 				"filenames/match-regex": "off",
 			},
 		},
+		{
+			files: ["**/*.spec.js", "**/*.test.js"],
+			rules: {
+				"no-magic-numbers": "off",
+			},
+		},
 	],
 	env: {
 		browser: true,
@@ -72,6 +78,7 @@ module.exports = {
 		"no-iterator": "error",
 		"no-labels": "error",
 		"no-lone-blocks": "error",
+		"no-magic-numbers": "error",
 		"no-multi-spaces": "error",
 		"no-new": "error",
 		"no-new-func": "error",

--- a/src/typescript.js
+++ b/src/typescript.js
@@ -26,6 +26,12 @@ module.exports = {
 				"multiline-comment-style": "off",
 			},
 		},
+		{
+			files: ["**/*.spec.ts", "**/*.test.ts"],
+			rules: {
+				"@typescript-eslint/no-magic-numbers": "off",
+			},
+		},
 	],
 	rules: {
 		/**
@@ -117,6 +123,8 @@ module.exports = {
 		"@typescript-eslint/no-invalid-this": "error",
 		"no-loss-of-precision": "off",
 		"@typescript-eslint/no-loss-of-precision": "error",
+		"no-magic-numbers": "off",
+		"@typescript-eslint/no-magic-numbers": "error",
 		"no-redeclare": "off",
 		"@typescript-eslint/no-redeclare": "error",
 		"no-shadow": "off",


### PR DESCRIPTION
## What this PR introduces?

<!-- Please, includes adescription of this pull request -->

- Add rule that prohibits the use of magic numbers

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] I have followed GitFlow pattern to create the branch
- [x] I have added all the `peerDependencies` needed as `devDependencies` too
- [x] I have added the new `peerDependecies` to the installation docs
- [x] I have tested the updates and it works

## PR Type

What kind of change does this PR introduce?

```
[ ] Hotfix
[ ] Bugfix
[x] Feature
[ ] Documentation update
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] CI/CD related changes
```

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information (Prints, details, etc)

To disable this rule, add this to your `.eslintrc.json`:

```
// common
"no-magic-numbers": "off",

// typescript
"@typescript-eslint/no-magic-numbers": "off",
```