### PR TITLE
Upgrade Version

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,13 +1,3 @@
 {
-	"recommendations": [
-		"editorconfig.editorconfig",
-		"irongeek.vscode-env",
-		"dbaeumer.vscode-eslint",
-		"eamodio.gitlens",
-		"bierner.markdown-preview-github-styles",
-		"pkief.material-icon-theme",
-		"gruntfuggly.todo-tree",
-		"shardulm94.trailing-spaces",
-		"yzhang.markdown-all-in-one"
-	]
+	"recommendations": ["techmmunity.extensions"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [5.1.3] - 2021-11-16
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+### Dependencies
+
+- Bump eslint-plugin-react-hooks
+- Bump @babel/eslint-parser from 7.15.8 to 7.16.0
+- Bump @babel/core from 7.15.8 to 7.16.0
+- Bump @next/eslint-plugin-next from 12.0.1 to 12.0.2
+- Bump @typescript-eslint/eslint-plugin from 5.2.0 to 5.3.0
+- Bump @typescript-eslint/parser from 5.2.0 to 5.3.0
+- Bump eslint-plugin-react-hooks
+- Bump eslint-plugin-jest from 25.2.2 to 25.2.3
+- Bump eslint from 8.1.0 to 8.2.0
+- Bump @rushstack/eslint-patch from 1.0.9 to 1.1.0
+- Bump @next/eslint-plugin-next from 12.0.2 to 12.0.3
+- Bump @typescript-eslint/parser from 5.3.0 to 5.3.1
+- Bump @typescript-eslint/eslint-plugin from 5.3.0 to 5.3.1
+- Bump eslint-plugin-jest from 25.2.3 to 25.2.4
+- Bump @babel/eslint-parser from 7.16.0 to 7.16.3
+- Bump eslint-plugin-react-hooks
+- Bump eslint-plugin-import from 2.25.2 to 2.25.3
+- Bump eslint-plugin-react from 7.26.1 to 7.27.0
+- Bump lint-staged from 11.2.6 to 12.0.2
+- Bump @typescript-eslint/parser from 5.3.1 to 5.4.0
+- Bump @next/eslint-plugin-next from 12.0.3 to 12.0.4
+- Bump @typescript-eslint/eslint-plugin from 5.3.1 to 5.4.0
+
 ## [5.1.2] - 2021-10-27
 
 ### Added
@@ -23,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Eslint v8 compatibility (upgrade dependencies)
+- ESLint v8 compatibility (upgrade dependencies)
 - `extends` order of modules
 - `allowLeadingUnderscore` for `ts-react` module
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@techmmunity/eslint-config",
-	"version": "5.1.2",
+	"version": "5.1.3",
 	"license": "Apache-2.0",
 	"author": "Techmmunity",
 	"description": "Techmmunity Style Guide",


### PR DESCRIPTION
## [5.1.3] - 2021-11-16

### Added

### Changed

### Fixed

### Removed

### Dependencies

- Bump eslint-plugin-react-hooks
- Bump @babel/eslint-parser from 7.15.8 to 7.16.0
- Bump @babel/core from 7.15.8 to 7.16.0
- Bump @next/eslint-plugin-next from 12.0.1 to 12.0.2
- Bump @typescript-eslint/eslint-plugin from 5.2.0 to 5.3.0
- Bump @typescript-eslint/parser from 5.2.0 to 5.3.0
- Bump eslint-plugin-react-hooks
- Bump eslint-plugin-jest from 25.2.2 to 25.2.3
- Bump eslint from 8.1.0 to 8.2.0
- Bump @rushstack/eslint-patch from 1.0.9 to 1.1.0
- Bump @next/eslint-plugin-next from 12.0.2 to 12.0.3
- Bump @typescript-eslint/parser from 5.3.0 to 5.3.1
- Bump @typescript-eslint/eslint-plugin from 5.3.0 to 5.3.1
- Bump eslint-plugin-jest from 25.2.3 to 25.2.4
- Bump @babel/eslint-parser from 7.16.0 to 7.16.3
- Bump eslint-plugin-react-hooks
- Bump eslint-plugin-import from 2.25.2 to 2.25.3
- Bump eslint-plugin-react from 7.26.1 to 7.27.0
- Bump lint-staged from 11.2.6 to 12.0.2
- Bump @typescript-eslint/parser from 5.3.1 to 5.4.0
- Bump @next/eslint-plugin-next from 12.0.3 to 12.0.4
- Bump @typescript-eslint/eslint-plugin from 5.3.1 to 5.4.0