### PR TITLE
[5.2.1] - 2022-01-06 - Fix TypeScript Dup Imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 
+## [5.2.1] - 2022-01-06
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Typescript `no-duplicate-imports`
+
+### Removed
+
+### Dependencies
+
 ## [5.2.0] - 2022-01-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@techmmunity/eslint-config",
-	"version": "5.2.0",
+	"version": "5.2.1",
 	"license": "Apache-2.0",
 	"author": "Techmmunity",
 	"description": "Techmmunity Style Guide",

--- a/src/configs/common.js
+++ b/src/configs/common.js
@@ -345,6 +345,8 @@ module.exports = {
 					"parent",
 					["sibling", "index"],
 					// eslint-disable-next-line prettier/prettier
+					["/\/configs?\//", "/^configs?$/"],
+					// eslint-disable-next-line prettier/prettier
 					["/\/enums?\//", "/\/types?\//", "/\/types?.(ts|js)$/"],
 				],
 				alphabetize: {

--- a/src/configs/typescript.js
+++ b/src/configs/typescript.js
@@ -134,6 +134,8 @@ module.exports = {
 		"@typescript-eslint/lines-between-class-members": "error",
 		"no-dupe-class-members": "off",
 		"@typescript-eslint/no-dupe-class-members": "error",
+		"no-duplicate-imports": "off",
+		"@typescript-eslint/no-duplicate-imports": "error",
 		"no-empty-function": "off",
 		"@typescript-eslint/no-empty-function": "off",
 		"no-invalid-this": "off",


### PR DESCRIPTION
## [5.2.1] - 2022-01-06

### Added

### Changed

### Fixed

- Typescript `no-duplicate-imports`

### Removed

### Dependencies