### PR TITLE
Fix "camelcase" rule on typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+### Dependencies
+
+## [5.2.2] - 2022-02-12
+
+### Added
+
 - `utils` imports category
 
 ### Changed
 
 - Imports that start with `enum` or `enums` will be in the types category
 - Imports that start with `type` or `types` will be in the types category
+- Disable `camelcase` rule when using `typescript` module, because it's unnecessary
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@techmmunity/eslint-config",
-	"version": "5.2.1",
+	"version": "5.2.2",
 	"license": "Apache-2.0",
 	"author": "Techmmunity",
 	"description": "Techmmunity Style Guide",

--- a/src/configs/typescript.js
+++ b/src/configs/typescript.js
@@ -70,6 +70,26 @@ module.exports = {
 		"@typescript-eslint/explicit-module-boundary-types": "off",
 		"@typescript-eslint/member-delimiter-style": "error",
 		"@typescript-eslint/method-signature-style": "error",
+		"@typescript-eslint/no-base-to-string": "error",
+		"@typescript-eslint/no-confusing-non-null-assertion": "error",
+		"@typescript-eslint/no-require-imports": "error",
+		"@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
+		"@typescript-eslint/no-unnecessary-type-arguments": "error",
+		"@typescript-eslint/no-unnecessary-type-constraint": "error",
+		"@typescript-eslint/prefer-enum-initializers": "error",
+		"@typescript-eslint/prefer-includes": "error",
+		"@typescript-eslint/prefer-literal-enum-member": "error",
+		"@typescript-eslint/prefer-optional-chain": "error",
+		"@typescript-eslint/prefer-readonly": "error",
+		"@typescript-eslint/prefer-string-starts-ends-with": "error",
+		"@typescript-eslint/sort-type-union-intersection-members": "error",
+		"@typescript-eslint/switch-exhaustiveness-check": "error",
+		"@typescript-eslint/type-annotation-spacing": "error",
+		"@typescript-eslint/unified-signatures": "error",
+		/**
+		 * Extension Rules
+		 */
+		"camelcase": "off",
 		"@typescript-eslint/naming-convention": [
 			"error",
 			{
@@ -99,25 +119,6 @@ module.exports = {
 				format: ["PascalCase"],
 			},
 		],
-		"@typescript-eslint/no-base-to-string": "error",
-		"@typescript-eslint/no-confusing-non-null-assertion": "error",
-		"@typescript-eslint/no-require-imports": "error",
-		"@typescript-eslint/no-unnecessary-boolean-literal-compare": "error",
-		"@typescript-eslint/no-unnecessary-type-arguments": "error",
-		"@typescript-eslint/no-unnecessary-type-constraint": "error",
-		"@typescript-eslint/prefer-enum-initializers": "error",
-		"@typescript-eslint/prefer-includes": "error",
-		"@typescript-eslint/prefer-literal-enum-member": "error",
-		"@typescript-eslint/prefer-optional-chain": "error",
-		"@typescript-eslint/prefer-readonly": "error",
-		"@typescript-eslint/prefer-string-starts-ends-with": "error",
-		"@typescript-eslint/sort-type-union-intersection-members": "error",
-		"@typescript-eslint/switch-exhaustiveness-check": "error",
-		"@typescript-eslint/type-annotation-spacing": "error",
-		"@typescript-eslint/unified-signatures": "error",
-		/**
-		 * Extension Rules
-		 */
 		"comma-dangle": "off",
 		"@typescript-eslint/comma-dangle": ["error", "always-multiline"],
 		"comma-spacing": "off",


### PR DESCRIPTION
## What does this PR introduce?

<!-- Please, includes a description of this pull request -->

`camelcase` is unnecessary when u have `@typescript-eslint/naming-convention`, what forces u to disable the `camelcase` rule on the entire file and then disable the `@typescript-eslint/naming-convention` for just the line that u want. This makes it harder to work with an external lib that doesn't follow the project pattern, like the AWS libs.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] I have followed GitFlow pattern to create the branch
- [x] I have added all the plugins and configs as `dependencies`
- [x] I have tested the updates using `yarn lk`, `yarn link @techmmunity/eslint-config` and checking in another project if it works

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Documentation update
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Dependencies update
[ ] CI/CD related changes
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information (Prints, details, etc)
